### PR TITLE
bugfix - fixing module matching

### DIFF
--- a/src/PHPUnit/Constraint/IsCurrentModuleNameConstraint.php
+++ b/src/PHPUnit/Constraint/IsCurrentModuleNameConstraint.php
@@ -40,7 +40,7 @@ final class IsCurrentModuleNameConstraint extends LaminasConstraint
 
         // Find Module from Controller
         foreach ($applicationConfig['modules'] as $appModules) {
-            if (strpos($controllerClass, $appModules) !== false) {
+            if (strpos($controllerClass, $appModules.'\\') !== false) {
                 if (strpos($appModules, '\\') !== false) {
                     $match = ltrim(substr($appModules, strrpos($appModules, '\\')), '\\');
                 } else {


### PR DESCRIPTION
I have corrected the corresponding match. So that the test runs successfully. However, I still don't know if that will solve your problem.

The scenario you described shows a problem when module name is only part of another module name.

Test -> TestModule

But your original problem was

Angebote -> Praktikum